### PR TITLE
remove inherited content nodes

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,22 +1,4 @@
-codecov:
-  token: e71cac93-7a3a-43e1-87cc-e04024210737
-  branch: master
-  bot: null
-  
-coverage:
-  precision: 2
-  round: down
-  range: "70...100"
-
 notify:
   gitter:
-    _custom_:
+    default:
       url: https://gitter.im/channingwalton/typeclassopedia
-      threshold: null
-      branches: null
-      message: null
-
-comment:
-  layout: "header, diff, changes, sunburst, uncovered"
-  branches: null
-  behavior: default


### PR DESCRIPTION
I'll follow up with you in Intercom too.
1. token is not needed for travis-ci testing
2. the rest of the data points are default, inherited by Codecov's defaults

Thanks :)
